### PR TITLE
Release 0.11.0: remove legacy guard API, require executeDecision

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Maven:
 <dependency>
     <groupId>io.github.mahdibohloul</groupId>
     <artifactId>statemachine</artifactId>
-    <version>0.10.0</version>
+    <version>0.11.0</version>
 </dependency>
 ```
 
@@ -168,7 +168,6 @@ class ValidatePaymentAction : OnTransformationAction<OrderContainer> {
 
 @Component
 class InventoryCheckGuard : OnTransformationGuard<OrderContainer> {
-  // Preferred: New-style API with GuardDecision (thread-safe)
   // Requires: import io.github.mahdibohloul.statemachine.guards.GuardDecision
   //          import io.github.mahdibohloul.statemachine.StateMachineErrorCodeString
   override fun executeDecision(container: OrderContainer): Mono<GuardDecision> =
@@ -183,11 +182,6 @@ class InventoryCheckGuard : OnTransformationGuard<OrderContainer> {
         )
       }
     }
-  
-  // Legacy: Deprecated boolean-based API (still supported for backward compatibility)
-  @Deprecated("Use executeDecision instead", ReplaceWith("executeDecision(container)"))
-  override fun execute(container: OrderContainer): Mono<Boolean> =
-    executeDecision(container).map { it.isAllowed() }
 }
 ```
 
@@ -403,24 +397,11 @@ class PaymentValidationGuard : OnTransformationGuard<OrderContainer> {
 }
 ```
 
-**Legacy Boolean API (Deprecated):**
-
-The legacy `execute()` method returning `Mono<Boolean>` is still supported for backward compatibility but is deprecated. The default implementation of `executeDecision()` adapts legacy guards automatically.
-
-```kotlin
-// Legacy approach (deprecated but still works)
-@Component
-class LegacyGuard : OnTransformationGuard<OrderContainer> {
-  @Deprecated("Use executeDecision instead")
-  override fun execute(container: OrderContainer): Mono<Boolean> =
-    Mono.just(validate(container))
-}
-```
+**Migrating from 0.10.x:** If you previously implemented `execute(container): Mono<Boolean>` (and optional `getValidationFailure*` hooks), replace that with `executeDecision(container): Mono<GuardDecision>` and return `GuardDecision.Allow` or `GuardDecision.Deny(errorCode, cause)`.
 
 **Benefits:**
 - **Thread-safe**: Error codes are captured in immutable `GuardDecision.Deny` objects
 - **Type-safe**: Sealed interface ensures exhaustive handling
-- **Backward compatible**: Legacy boolean-based guards continue to work
 - **Rich error information**: Error codes and causes are explicitly captured
 
 ---
@@ -862,7 +843,7 @@ class OrderTransformerTest {
 
 ### 4. Guard Design
 - Guards should be pure validation logic
-- Prefer `executeDecision()` returning `GuardDecision` over legacy `execute()` returning `Boolean`
+- Implement `executeDecision()` returning `GuardDecision` (`Allow` or `Deny` with error code and cause)
 - Use `GuardDecision.Deny` with specific error codes and causes for failed validations
 - Return meaningful error codes and exception causes for better error handling
 - Consider using domain-specific exception types in `GuardDecision.Deny`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.mahdibohloul"
-version = "0.10.0"
+version = "0.11.0"
 description = "statemachine"
 
 java {

--- a/src/main/kotlin/io/github/mahdibohloul/statemachine/guards/OnTransformationGuard.kt
+++ b/src/main/kotlin/io/github/mahdibohloul/statemachine/guards/OnTransformationGuard.kt
@@ -1,8 +1,6 @@
 package io.github.mahdibohloul.statemachine.guards
 
-import box.tapsi.libs.utilities.ErrorCodeString
 import box.tapsi.libs.utilities.getOriginalClass
-import io.github.mahdibohloul.statemachine.StateMachineErrorCodeString
 import io.github.mahdibohloul.statemachine.StateMachineException
 import io.github.mahdibohloul.statemachine.TransformationContainer
 import reactor.core.publisher.Mono
@@ -17,51 +15,18 @@ import reactor.core.publisher.SynchronousSink
  */
 interface OnTransformationGuard<TContainer : TransformationContainer<*>> {
   /**
-   * Executes the provided transformation guard logic against the specified container.
-   *
-   * @param container The container representing the transformation context on which the guard logic will be executed.
-   * @return A Mono that emits a Boolean indicating whether the guard condition was satisfied (true) or not (false).
-   */
-  @Deprecated(
-    message = "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith(
-      "executeDecision(container: TContainer): Mono<GuardDecision>",
-      "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-    ),
-  )
-  fun execute(container: TContainer): Mono<Boolean>
-
-  /**
-   * Executes the guard and maps the result to a GuardDecision.
-   *
-   * This is the preferred, new-style API for guard implementations.
-   * The default implementation adapts legacy boolean-based guards by using
-   * [getValidationFailureErrorCodeString] and [getValidationFailureCause] to produce a [GuardDecision].
-   *
-   * New implementations should override this method directly instead of [execute].
+   * Executes the guard and maps the result to a [GuardDecision].
    *
    * @param container The transformation container to be validated.
    * @return A Mono emitting a GuardDecision based on the execution result.
    */
-  fun executeDecision(container: TContainer): Mono<GuardDecision> = execute(container)
-    .map { allowed ->
-      if (allowed) {
-        GuardDecision.Allow
-      } else {
-        GuardDecision.Deny(
-          errorCode = getValidationFailureErrorCodeString(),
-          cause = getValidationFailureCause(),
-        )
-      }
-    }
+  fun executeDecision(container: TContainer): Mono<GuardDecision>
 
   /**
    * Validates the given transformation container using a guard and emits the result.
    * If validation fails, an error is emitted encapsulating details about the failure.
    *
-   * This method is built on top of [executeDecision] and works seamlessly with both legacy boolean-based guards
-   * and new-style guards returning [GuardDecision].
+   * This method is built on top of [executeDecision].
    *
    * @param container The transformation container to be validated.
    * @return A Mono emitting `true` if validation succeeds, otherwise emits an error.
@@ -81,42 +46,4 @@ interface OnTransformationGuard<TContainer : TransformationContainer<*>> {
         )
       }
     }
-
-  /**
-   * Provides the error code string associated with a guard validation failure.
-   *
-   * This method is only consulted when [executeDecision] is not overridden.
-   * It serves as a legacy extension point for boolean-based guards and is kept for backward compatibility.
-   *
-   * @return The specific error code string representing guard validation failure.
-   */
-  @Deprecated(
-    message = "Legacy hook for boolean-based guards. Override executeDecision(container) " +
-      "and return GuardDecision.Deny(errorCode, cause) instead.",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith(
-      "executeDecision(container: TContainer): Mono<GuardDecision>",
-      "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-    ),
-  )
-  fun getValidationFailureErrorCodeString(): ErrorCodeString = StateMachineErrorCodeString.GuardValidationFailed
-
-  /**
-   * Retrieves the cause of the validation failure, if available.
-   *
-   * This method is only used by the default [executeDecision] adapter for legacy boolean-based guards.
-   * New guards should encode the cause directly in [GuardDecision.Deny] returned from [executeDecision].
-   *
-   * @return A Throwable representing the cause of the validation failure, or null if no cause is available.
-   */
-  @Deprecated(
-    message = "Legacy hook for boolean-based guards. Provide failure details via GuardDecision.Deny " +
-      "in executeDecision(container) instead.",
-    level = DeprecationLevel.WARNING,
-    replaceWith = ReplaceWith(
-      "executeDecision(container: TContainer): Mono<GuardDecision>",
-      "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-    ),
-  )
-  fun getValidationFailureCause(): Throwable? = null
 }

--- a/src/main/kotlin/io/github/mahdibohloul/statemachine/support/CompositeBehaviors.kt
+++ b/src/main/kotlin/io/github/mahdibohloul/statemachine/support/CompositeBehaviors.kt
@@ -49,24 +49,12 @@ class CompositeBehaviors {
   class CompositeOnTransformationGuard<TContainer : TransformationContainer<*>>(
     private val guards: MutableList<OnTransformationGuard<TContainer>>,
   ) : OnTransformationGuard<TContainer> {
-    @Deprecated(
-      "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-      replaceWith = ReplaceWith(
-        "executeDecision(container: TContainer): Mono<GuardDecision>",
-        "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-      ),
-      level = DeprecationLevel.WARNING,
-    )
-    override fun execute(container: TContainer): Mono<Boolean> = guards.fold(true.toMono()) { acc, guard ->
-      acc.filter { it }.flatMap { guard.execute(container) }.defaultIfEmpty(false)
-    }
-
     override fun executeDecision(
       container: TContainer,
     ): Mono<GuardDecision> = guards.fold(Mono.just(GuardDecision.Allow)) { acc, guard ->
       acc.flatMap { decision ->
         if (decision.isDenied()) {
-          return@flatMap Mono.just(decision)
+          return@flatMap decision.toMono()
         }
 
         return@flatMap guard.executeDecision(container)

--- a/src/main/kotlin/io/github/mahdibohloul/statemachine/support/DefaultBehaviors.kt
+++ b/src/main/kotlin/io/github/mahdibohloul/statemachine/support/DefaultBehaviors.kt
@@ -25,15 +25,6 @@ class DefaultBehaviors {
   }
 
   class DefaultOnTransformationGuard<TContainer : TransformationContainer<*>> : OnTransformationGuard<TContainer> {
-    @Deprecated(
-      "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-      replaceWith = ReplaceWith(
-        "executeDecision(container: TContainer): Mono<GuardDecision>",
-        "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-      ),
-      level = DeprecationLevel.WARNING,
-    )
-    override fun execute(container: TContainer): Mono<Boolean> = true.toMono()
     override fun executeDecision(container: TContainer): Mono<GuardDecision> = GuardDecision.Allow.toMono()
   }
 

--- a/src/main/kotlin/io/github/mahdibohloul/statemachine/support/guards/GuardChoicePointTransformationGuard.kt
+++ b/src/main/kotlin/io/github/mahdibohloul/statemachine/support/guards/GuardChoicePointTransformationGuard.kt
@@ -4,9 +4,10 @@ import io.github.mahdibohloul.statemachine.TransformationContainer
 import io.github.mahdibohloul.statemachine.choices.OnTransformationChoice
 import io.github.mahdibohloul.statemachine.guards.GuardDecision
 import io.github.mahdibohloul.statemachine.guards.OnTransformationGuard
-import io.github.mahdibohloul.statemachine.guards.isAllowed
+import io.github.mahdibohloul.statemachine.guards.isDenied
 import io.github.mahdibohloul.statemachine.support.DefaultBehaviors
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
 
 class GuardChoicePointTransformationGuard<TContainer : TransformationContainer<*>>(
   val choicePoint: OnTransformationChoice<TContainer>,
@@ -14,33 +15,21 @@ class GuardChoicePointTransformationGuard<TContainer : TransformationContainer<*
   val chosenGuard: OnTransformationGuard<TContainer> = DefaultBehaviors.DefaultOnTransformationGuard(),
   val otherwiseGuard: OnTransformationGuard<TContainer> = DefaultBehaviors.DefaultOnTransformationGuard(),
 ) : OnTransformationGuard<TContainer> {
-  @Deprecated(
-    "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-    replaceWith = ReplaceWith(
-      "executeDecision(container: TContainer): Mono<GuardDecision>",
-      "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-    ),
-    level = DeprecationLevel.WARNING,
-  )
-  override fun execute(container: TContainer): Mono<Boolean> = baseGuard.execute(container)
-    .filter { it }
-    .flatMap { choicePoint.isChosen(container) }
-    .flatMap { isChosen ->
-      if (isChosen) {
-        return@flatMap chosenGuard.execute(container)
-      }
-      return@flatMap otherwiseGuard.execute(container)
-    }.defaultIfEmpty(false)
-
   override fun executeDecision(container: TContainer): Mono<GuardDecision> = baseGuard.executeDecision(container)
-    .filter { it.isAllowed() }
-    .flatMap { choicePoint.isChosen(container) }
-    .flatMap { isChosen ->
-      if (isChosen) {
-        return@flatMap chosenGuard.executeDecision(container)
+    .flatMap { baseDecision ->
+      if (baseDecision.isDenied()) {
+        return@flatMap baseDecision.toMono()
       }
-      return@flatMap otherwiseGuard.executeDecision(container)
-    }.defaultIfEmpty(GuardDecision.Deny())
+
+      return@flatMap choicePoint.isChosen(container)
+        .flatMap { isChosen ->
+          if (isChosen) {
+            chosenGuard.executeDecision(container)
+          } else {
+            otherwiseGuard.executeDecision(container)
+          }
+        }
+    }
 
   override fun validate(container: TContainer): Mono<Boolean> = baseGuard.validate(container)
     .flatMap { choicePoint.isChosen(container) }

--- a/src/test/kotlin/io/github/mahdibohloul/statemachine/StateMachineTestHelper.kt
+++ b/src/test/kotlin/io/github/mahdibohloul/statemachine/StateMachineTestHelper.kt
@@ -2,6 +2,7 @@ package io.github.mahdibohloul.statemachine
 
 import io.github.mahdibohloul.statemachine.actions.OnTransformationAction
 import io.github.mahdibohloul.statemachine.choices.OnTransformationChoice
+import io.github.mahdibohloul.statemachine.guards.GuardDecision
 import io.github.mahdibohloul.statemachine.guards.OnTransformationGuard
 import io.github.mahdibohloul.statemachine.handlers.OnTransformationErrorHandler
 import io.github.mahdibohloul.statemachine.providers.TransformationContainerProvider
@@ -41,27 +42,11 @@ object StateMachineTestHelper {
   }
 
   class TrueTransformationGuard : OnTransformationGuard<TestContainer> {
-    @Deprecated(
-      "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-      replaceWith = ReplaceWith(
-        "executeDecision(container: TContainer): Mono<GuardDecision>",
-        "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-      ),
-      level = DeprecationLevel.WARNING,
-    )
-    override fun execute(container: TestContainer): Mono<Boolean> = true.toMono()
+    override fun executeDecision(container: TestContainer): Mono<GuardDecision> = GuardDecision.Allow.toMono()
   }
 
   class FalseTransformationGuard : OnTransformationGuard<TestContainer> {
-    @Deprecated(
-      "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-      replaceWith = ReplaceWith(
-        "executeDecision(container: TContainer): Mono<GuardDecision>",
-        "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-      ),
-      level = DeprecationLevel.WARNING,
-    )
-    override fun execute(container: TestContainer): Mono<Boolean> = false.toMono()
+    override fun executeDecision(container: TestContainer): Mono<GuardDecision> = GuardDecision.Deny().toMono()
   }
 
   class TrueTransformationChoice : OnTransformationChoice<TestContainer> {

--- a/src/test/kotlin/io/github/mahdibohloul/statemachine/factories/OnTransformationGuardFactoryTest.kt
+++ b/src/test/kotlin/io/github/mahdibohloul/statemachine/factories/OnTransformationGuardFactoryTest.kt
@@ -27,15 +27,6 @@ class OnTransformationGuardFactoryTest {
   ) : TransformationContainer<NotMatchEnum>
 
   class NotMatchTransformationGuard : OnTransformationGuard<NotMatchContainer> {
-    @Deprecated(
-      "Legacy boolean-based guard execution method. Use executeDecision(container) instead.",
-      replaceWith = ReplaceWith(
-        "executeDecision(container: TContainer): Mono<GuardDecision>",
-        "io.github.mahdibohloul.statemachine.guards.GuardDecision",
-      ),
-      level = DeprecationLevel.WARNING,
-    )
-    override fun execute(container: NotMatchContainer): Mono<Boolean> = true.toMono()
     override fun executeDecision(container: NotMatchContainer): Mono<GuardDecision> = GuardDecision.Allow.toMono()
   }
 

--- a/src/test/kotlin/io/github/mahdibohloul/statemachine/support/CompositeBehaviorsTest.kt
+++ b/src/test/kotlin/io/github/mahdibohloul/statemachine/support/CompositeBehaviorsTest.kt
@@ -2,6 +2,7 @@ package io.github.mahdibohloul.statemachine.support
 
 import io.github.mahdibohloul.statemachine.StateMachineException
 import io.github.mahdibohloul.statemachine.StateMachineTestHelper
+import io.github.mahdibohloul.statemachine.guards.GuardDecision
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
@@ -54,7 +55,7 @@ class CompositeBehaviorsTest {
   }
 
   @Test
-  fun `should return true when all guards returns true`() {
+  fun `should allow when all guards allow`() {
     // given
     val trueGuard = spy(StateMachineTestHelper.TrueTransformationGuard())
     val compositeOnTransformationGuard = CompositeBehaviors.CompositeOnTransformationGuard(
@@ -63,17 +64,17 @@ class CompositeBehaviorsTest {
     val container = StateMachineTestHelper.TestContainer()
 
     // when
-    compositeOnTransformationGuard.execute(container)
+    compositeOnTransformationGuard.executeDecision(container)
       .test()
-      .expectNext(true)
+      .expectNext(GuardDecision.Allow)
       .verifyComplete()
 
     // verify
-    verify(trueGuard, times(3)).execute(container)
+    verify(trueGuard, times(3)).executeDecision(container)
   }
 
   @Test
-  fun `should fail-fast if an earlier guard fails sooner`() {
+  fun `should fail-fast if an earlier guard deny sooner`() {
     // given
     val trueGuard = spy(StateMachineTestHelper.TrueTransformationGuard())
     val falseGuard = spy(StateMachineTestHelper.FalseTransformationGuard())
@@ -83,14 +84,14 @@ class CompositeBehaviorsTest {
     val container = StateMachineTestHelper.TestContainer()
 
     // when
-    compositeOnTransformationGuard.execute(container)
+    compositeOnTransformationGuard.executeDecision(container)
       .test()
-      .expectNext(false)
+      .expectNext(GuardDecision.Deny())
       .verifyComplete()
 
     // verify
-    verify(trueGuard, times(1)).execute(container)
-    verify(falseGuard, times(1)).execute(container)
+    verify(trueGuard, times(1)).executeDecision(container)
+    verify(falseGuard, times(1)).executeDecision(container)
   }
 
   @Test
@@ -104,14 +105,14 @@ class CompositeBehaviorsTest {
     val container = StateMachineTestHelper.TestContainer()
 
     // when
-    compositeOnTransformationGuard.execute(container)
+    compositeOnTransformationGuard.executeDecision(container)
       .test()
-      .expectNext(false)
+      .expectNext(GuardDecision.Deny())
       .verifyComplete()
 
     // verify
-    verify(trueGuard, times(1)).execute(container)
-    verify(falseGuard, times(1)).execute(container)
+    verify(trueGuard, times(1)).executeDecision(container)
+    verify(falseGuard, times(1)).executeDecision(container)
   }
 
   @Test
@@ -136,7 +137,7 @@ class CompositeBehaviorsTest {
   }
 
   @Test
-  fun `should return true when all validations are successful`() {
+  fun `should allow when all validations are successful`() {
     // given
     val trueGuard = spy(StateMachineTestHelper.TrueTransformationGuard())
     val compositeOnTransformationGuard = CompositeBehaviors.CompositeOnTransformationGuard(
@@ -249,7 +250,7 @@ class CompositeBehaviorsTest {
   }
 
   @Test
-  fun `should return true when all choices return true`() {
+  fun `should allow when all choices allow`() {
     // given
     val trueChoice = spy(StateMachineTestHelper.TrueTransformationChoice())
     val compositeOnTransformationChoice = CompositeBehaviors.CompositeOnTransformationChoice(
@@ -331,7 +332,7 @@ class CompositeBehaviorsTest {
   }
 
   @Test
-  fun `should return true when only one choice exists and it returns true`() {
+  fun `should allow when only one choice exists and it allow`() {
     // given
     val trueChoice = spy(StateMachineTestHelper.TrueTransformationChoice())
     val compositeOnTransformationChoice = CompositeBehaviors.CompositeOnTransformationChoice(

--- a/src/test/kotlin/io/github/mahdibohloul/statemachine/support/DefaultBehaviorsTest.kt
+++ b/src/test/kotlin/io/github/mahdibohloul/statemachine/support/DefaultBehaviorsTest.kt
@@ -2,6 +2,7 @@ package io.github.mahdibohloul.statemachine.support
 
 import io.github.mahdibohloul.statemachine.StateMachineException
 import io.github.mahdibohloul.statemachine.StateMachineTestHelper
+import io.github.mahdibohloul.statemachine.guards.GuardDecision
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verifyNoInteractions
@@ -43,16 +44,16 @@ class DefaultBehaviorsTest {
   }
 
   @Test
-  fun `the default on transformation guard should return true`() {
+  fun `the default on transformation guard should allow`() {
     // given
     val container = spy(StateMachineTestHelper.TestContainer())
     val defaultOnTransformationGuard =
       DefaultBehaviors.DefaultOnTransformationGuard<StateMachineTestHelper.TestContainer>()
 
     // when
-    defaultOnTransformationGuard.execute(container)
+    defaultOnTransformationGuard.executeDecision(container)
       .test()
-      .expectNext(true)
+      .expectNext(GuardDecision.Allow)
       .verifyComplete()
 
     // verify


### PR DESCRIPTION
BREAKING CHANGE: OnTransformationGuard no longer defines execute(Mono<Boolean>) or the getValidationFailure* hooks. Implement executeDecision returning GuardDecision only.

- Default, composite, and choice-point guards updated accordingly
- Tests and README aligned; migration note for 0.10.x consumers

Made-with: Cursor